### PR TITLE
fix(message): correct JSON parsing to avoid truncating payloads conta…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,11 @@
     </properties>
 
     <dependencies>
-        <!-- Dependências podem ser adicionadas aqui -->
-        <!-- Exemplo: JUnit 5 para testes -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/src/main/java/me.m41k0n/domain/Message.java
+++ b/src/main/java/me.m41k0n/domain/Message.java
@@ -1,5 +1,7 @@
 package me.m41k0n.domain;
 
+import com.google.gson.Gson;
+
 public class Message {
 
     private final String type;
@@ -16,11 +18,25 @@ public class Message {
         this.signature = signature;
     }
 
-    public String getType() { return type; }
-    public String getFrom() { return from; }
-    public String getTo() { return to; }
-    public String getPayload() { return payload; }
-    public String getSignature() { return signature; }
+    public String getType() {
+        return type;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public String getTo() {
+        return to;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public String getSignature() {
+        return signature;
+    }
 
     public String toJson() {
         return String.format(
@@ -30,18 +46,7 @@ public class Message {
     }
 
     public static Message fromJson(String json) {
-        String[] parts = json.replace("{", "").replace("}", "").replace("\"", "").split(",");
-        String type = "", from = "", to = "", payload = "", signature = "";
-        for (String p : parts) {
-            String[] kv = p.split(":");
-            switch (kv[0]) {
-                case "type": type = kv[1]; break;
-                case "from": from = kv[1]; break;
-                case "to": to = kv[1]; break;
-                case "payload": payload = kv[1]; break;
-                case "signature": signature = kv[1]; break;
-            }
-        }
-        return new Message(type, from, to, payload, signature);
+        Gson gson = new Gson();
+        return gson.fromJson(json, Message.class);
     }
 }


### PR DESCRIPTION
…ining commas

The previous manual JSON parser split fields by comma, which broke when the payload included commas (e.g. "Hi, I am here!"). This resulted in incomplete payload extraction and signature verification failures. Switched to a proper JSON library to ensure the payload field is correctly deserialized, regardless of its contents.